### PR TITLE
Add play_media method. 

### DIFF
--- a/examples/play.py
+++ b/examples/play.py
@@ -1,0 +1,46 @@
+from roonapi import RoonApi
+
+appinfo = {
+    "extension_id": "python_roon_test",
+    "display_name": "Python library for Roon",
+    "display_version": "1.0.0",
+    "publisher": "gregd",
+    "email": "mygreat@emailaddress.com",
+}
+
+server = "192.168.1.160"
+target_zone = "Mixing Speakers"
+# Can be None if you don't yet have a token
+token = open("mytokenfile").read()
+
+roonapi = RoonApi(appinfo, token, server)
+
+# get target zone output_id
+zones = roonapi.zones
+output_id = [
+    output["zone_id"]
+    for output in zones.values()
+    if output["display_name"] == target_zone
+][0]
+print("OUTPUT ID", output_id)
+
+# Examples of using play_media
+print("RADIO")
+items = roonapi.play_media(output_id, ["My Live Radio", "BBC Radio 4"])
+
+print("SINGLE ARTIST")
+items = roonapi.play_media(output_id, ["Library", "Artists", "Neil Young"])
+
+print("SINGLE ARTIST ALBUM")
+items = roonapi.play_media(
+    output_id, ["Library", "Artists", "Neil Young", "After The Goldrush"]
+)
+
+print("PLAY SINGLE ARTIST ALBUM - use Queue")
+items = roonapi.play_media(
+    output_id, ["Library", "Artists", "Neil Young", "Harvest"], "Queue"
+)
+
+# save the token for next time
+with open("mytokenfile", "w") as f:
+    f.write(roonapi.token)

--- a/roonapi/constants.py
+++ b/roonapi/constants.py
@@ -22,6 +22,7 @@ MESSAGE_REQUEST = "REQUEST"
 MESSAGE_COMPLETE = "COMPLETE"
 MESSAGE_CONTINUE = "CONTINUE"
 
+PAGE_SIZE = 100
 
 LOG_FORMAT = logging.Formatter(
     "%(asctime)-15s %(levelname)-5s  %(module)s -- %(message)s"


### PR DESCRIPTION
This adds a `play_media` method which  provides an easier way to play specific tracks / radio. It also also avoids hardcoding the roon strings (which changed in roon v1.7 and broke the library).

The downside is that users of the call will need to have some information about the roon browse structure (but since it's very clode to the roon app - that's probably fine)

It will replace the other `play_ `commands at some point.