### PR TITLE
Add pause_all api call.

### DIFF
--- a/roonapi/roonapi.py
+++ b/roonapi/roonapi.py
@@ -160,7 +160,7 @@ class RoonApi:  # pylint: disable=too-many-instance-attributes
         """
         Pause all zones.
         """
-        return self._request(SERVICE_TRANSPORT + "/pause_all") 
+        return self._request(SERVICE_TRANSPORT + "/pause_all")
 
     def standby(self, output_id, control_key=None):
         """

--- a/roonapi/roonapi.py
+++ b/roonapi/roonapi.py
@@ -156,6 +156,12 @@ class RoonApi:  # pylint: disable=too-many-instance-attributes
         data = {"zone_or_output_id": zone_or_output_id, "control": control}
         return self._request(SERVICE_TRANSPORT + "/control", data)
 
+    def pause_all(self):
+        """
+        Pause all zones.
+        """
+        return self._request(SERVICE_TRANSPORT + "/pause_all") 
+
     def standby(self, output_id, control_key=None):
         """
         Send standby command to the specified output.

--- a/roonapi/roonapi.py
+++ b/roonapi/roonapi.py
@@ -157,9 +157,7 @@ class RoonApi:  # pylint: disable=too-many-instance-attributes
         return self._request(SERVICE_TRANSPORT + "/control", data)
 
     def pause_all(self):
-        """
-        Pause all zones.
-        """
+        "Pause all zones."
         return self._request(SERVICE_TRANSPORT + "/pause_all")
 
     def standby(self, output_id, control_key=None):

--- a/roonapi/roonapi.py
+++ b/roonapi/roonapi.py
@@ -157,7 +157,7 @@ class RoonApi:  # pylint: disable=too-many-instance-attributes
         return self._request(SERVICE_TRANSPORT + "/control", data)
 
     def pause_all(self):
-        "Pause all zones."
+        """Pause all zones."""
         return self._request(SERVICE_TRANSPORT + "/pause_all")
 
     def standby(self, output_id, control_key=None):


### PR DESCRIPTION
I've added a method for the _pause_all_ API call which takes no arguments, documented in https://roonlabs.github.io/node-roon-api/RoonApiTransport.html