### PR TITLE
Bring back support for volume control endpoints

### DIFF
--- a/roonapi/roonapi.py
+++ b/roonapi/roonapi.py
@@ -10,6 +10,7 @@ from .constants import (
     SERVICE_BROWSE,
     SERVICE_REGISTRY,
     SERVICE_TRANSPORT,
+    CONTROL_VOLUME,
 )
 from .discovery import RoonDiscovery
 from .roonapisocket import RoonApiWebSocket
@@ -50,6 +51,10 @@ class RoonApi:  # pylint: disable=too-many-instance-attributes
     _outputs = {}
     _state_callbacks = []
     ready = False
+
+    _volume_controls_request_id = None
+    _volume_controls = {}
+    _state_callbacks = []
 
     @property
     def token(self):
@@ -647,18 +652,20 @@ class RoonApi:  # pylint: disable=too-many-instance-attributes
 
         self._roonsocket.register_connected_callback(self._socket_connected)
         self._roonsocket.register_registered_calback(self._server_registered)
-
+        self._roonsocket.register_volume_controls_callback(self._on_volume_control_request)
+        
         self._roonsocket.start()
 
     def _socket_connected(self):
         """Successfully connected the websocket."""
         LOGGER.info("Connection with roon websockets (re)created.")
         self.ready = False
+        self._volume_controls_request_id = None
         # authenticate / register
         # warning: at first launch the user has to approve the app in the Roon settings.
         appinfo = self._appinfo.copy()
         appinfo["required_services"] = [SERVICE_TRANSPORT, SERVICE_BROWSE]
-        appinfo["provided_services"] = []
+        appinfo["provided_services"] = [CONTROL_VOLUME]
         if self._token:
             appinfo["token"] = self._token
         if not self._token:
@@ -807,3 +814,67 @@ class RoonApi:  # pylint: disable=too-many-instance-attributes
                 if not self._exit:
                     self._server_discovered(self._host, self._port)
             time.sleep(2)
+
+    def register_volume_control(self, control_key, display_name, callback, initial_volume=0, volume_type="number", volume_step=2, volume_min=0, volume_max=100, is_muted=False):
+        ''' register a new volume control on the api'''
+        if control_key in self._volume_controls:
+            LOGGER.error("source_control %s is already registered!" % control_key)
+            return
+        control_data = {
+                    "display_name": display_name,
+                    "volume_type": volume_type,
+                    "volume_min": volume_min,
+                    "volume_max": volume_max,
+                    "volume_value": initial_volume,
+                    "volume_step": volume_step,
+                    "is_muted": is_muted,
+                    "control_key": control_key
+                    }
+        self._volume_controls[control_key] = (callback, control_data)
+        if self._volume_controls_request_id:
+            data = {"controls_added":[ control_data ]}
+            self._roonsocket.send_continue(self._volume_controls_request_id, data)
+
+    def update_volume_control(self, control_key, volume=None, mute=None):
+        ''' update an existing volume control, report its state to Roon '''
+        if control_key not in self._volume_controls:
+            LOGGER.warning("volume_control %s is not (yet) registered!" % control_key)
+            return
+        if not self._volume_controls_request_id:
+            LOGGER.warning("Not yet registered, can not update volume control")
+            return False
+        if volume != None:
+            self._volume_controls[control_key][1]["volume_value"] = volume
+        if mute != None:
+            self._volume_controls[control_key][1]["is_muted"] = mute
+        data = {"controls_changed": [ self._volume_controls[control_key][1] ] }
+        self._roonsocket.send_continue(self._volume_controls_request_id, data)
+
+    def _on_volume_control_request(self, event, request_id, data):
+        ''' got request from roon server for a volume control registered on this endpoint'''
+        if event == "subscribe_controls":
+            LOGGER.debug("found subscription ID for volume controls: %s " % request_id)
+            # send all volume controls already registered (handle connection loss)
+            controls = []
+            for callback, control_data in self._volume_controls.values():
+                controls.append(control_data)
+            self._roonsocket.send_continue(request_id, { "controls_added":controls })
+            self._volume_controls_request_id = request_id
+        elif data and data.get("control_key"):
+            control_key = data["control_key"]
+            if event == "set_volume" and data["mode"] == "absolute":
+                value = data["value"]
+            elif event == "set_volume" and data["mode"] == "relative":
+                value = self._volume_controls[control_key][0]["volume_value"] + data["value"]
+            elif event == "set_volume" and data["mode"] == "relative_step":
+                value = self._volume_controls[control_key][0]["volume_value"] + (data["value"] * data["volume_step"])
+            elif event == "set_mute":
+                value = data["mode"] == "on"
+            else:
+                return
+            try:
+                self._roonsocket.send_complete(request_id, "Success")
+                self._volume_controls[control_key][0](control_key, event, value)
+            except Exception:
+                LOGGER.exception("Error in volume_control callback")
+                self._roonsocket.send_complete(request_id, "Error")

--- a/roonapi/roonapisocket.py
+++ b/roonapi/roonapisocket.py
@@ -4,7 +4,7 @@ import threading
 
 import websocket
 
-from .constants import LOGGER, REGISTERED, SERVICE_PING
+from .constants import LOGGER, REGISTERED, SERVICE_PING, CONTROL_VOLUME
 
 try:
     import simplejson as json
@@ -37,7 +37,7 @@ class RoonApiWebSocket(
 
     def register_source_controls_callback(self, callback):
         """To be called on source changes."""
-        self._volume_controls_callback = callback
+        self._source_controls_callback = callback
 
     def register_volume_controls_callback(self, callback):
         """To be called on volume changes."""
@@ -150,6 +150,11 @@ class RoonApiWebSocket(
                 self.send_complete(request_id, "Success")
             elif REGISTERED in header:
                 self._registered_calback(body)
+            elif CONTROL_VOLUME in header:
+                # incoming message for volume_control endpoint
+                event = header.split("/")[-1]
+                if self._volume_controls_callback:
+                    self._volume_controls_callback(event, request_id, body)
             elif request_id in self._subscriptions:
                 # this is callback for one of our subscriptions
                 self._subscriptions[request_id]["callback"](body)


### PR DESCRIPTION
I've restored support for Volume Control Endpoints.
I'm using this functionality to control volume on my Soekris R2R DAC (dam1021) using built-in HW volume control.
As an example of usage you can see my dac extension:

https://github.com/SebuZet/soekris_dac_roon
