### PR TITLE
Revise startup logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ dist/
 roonapi.egg-info/
 .venv
 venv
-mytokenfile
+my_token_file
+my_core_id_file

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -10,11 +10,13 @@ appinfo = {
 
 # Can be None if you don't yet have a token
 token = open("mytokenfile").read()
+# token = None
 
 # Take a look at examples/discovery if you want to use discovery.
-server = "192.168.3.60"
+host = "192.168.3.61"
+port = 9330
 
-roonapi = RoonApi(appinfo, token, server)
+roonapi = RoonApi(appinfo, token, host, port)
 
 # get all zones (as dict)
 print(roonapi.zones)

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -1,4 +1,4 @@
-from roonapi import RoonApi
+from roonapi import RoonApi, RoonDiscovery
 
 appinfo = {
     "extension_id": "python_roon_test",
@@ -9,21 +9,21 @@ appinfo = {
 }
 
 # Can be None if you don't yet have a token
-token = open("mytokenfile").read()
-# token = None
+try:
+    core_id = open("my_core_id_file").read()
+    token = open("my_token_file").read()
+except OSError:
+    print("Please authorise first using discovery.py")
+    exit()
 
-# Take a look at examples/discovery if you want to use discovery.
-host = "192.168.3.61"
-port = 9330
+discover = RoonDiscovery(core_id)
+server = discover.first()
+discover.stop()
 
-roonapi = RoonApi(appinfo, token, host, port)
+roonapi = RoonApi(appinfo, token, server[0], server[1], True)
 
 # get all zones (as dict)
 print(roonapi.zones)
 
 # get all outputs (as dict)
 print(roonapi.outputs)
-
-# save the token for next time
-with open("mytokenfile", "w") as f:
-    f.write(roonapi.token)

--- a/examples/discovery.py
+++ b/examples/discovery.py
@@ -41,14 +41,7 @@ for api in apis:
 core_id = api.core_id
 token = api.token
 
-print("Find authorised server via discovery")
-discover = RoonDiscovery(core_id)
-server = discover.first()
-discover.stop()
-
-roonapi = RoonApi(appinfo, token, server[0], server[1], True, core_id)
-print(api.host)
-print(api.core_name)
-print(api.core_id)
-print("Call the API")
-print(roonapi.zones)
+with open("my_core_id_file", "w") as f:
+    f.write(api.core_id)
+with open("my_token_file", "w") as f:
+    f.write(api.token)

--- a/examples/discovery.py
+++ b/examples/discovery.py
@@ -12,6 +12,12 @@ appinfo = {
 
 discover = RoonDiscovery(None)
 servers = discover.all()
+
+print("Shutdown discovery")
+discover.stop()
+
+print("Found the following servers")
+print(servers)
 apis = [RoonApi(appinfo, None, server[0], server[1], False) for server in servers]
 
 auth_api = []
@@ -27,17 +33,22 @@ print(api.host)
 print(api.core_name)
 print(api.core_id)
 
+print("Shutdown apis")
+for api in apis:
+    api.stop()
+
 # This is what we need to reconnect
 core_id = api.core_id
 token = api.token
 
-print("Shutdown discovery")
-discover.stop()
-for api in apis:
-    api.stop()
-
 print("Find authorised server via discovery")
-roonapi = RoonApi(appinfo, token, None, None, True, core_id)
+discover = RoonDiscovery(core_id)
+server = discover.first()
+discover.stop()
 
+roonapi = RoonApi(appinfo, token, server[0], server[1], True, core_id)
+print(api.host)
+print(api.core_name)
+print(api.core_id)
 print("Call the API")
 print(roonapi.zones)

--- a/examples/groups.py
+++ b/examples/groups.py
@@ -1,4 +1,4 @@
-from roonapi import RoonApi
+from roonapi import RoonApi, RoonDiscovery
 
 appinfo = {
     "extension_id": "python_roon_test",
@@ -8,16 +8,18 @@ appinfo = {
     "email": "mygreat@emailaddress.com",
 }
 
-# Can be None if you don't yet have a token
-token = open("mytokenfile").read()
-# token= None
+try:
+    core_id = open("my_core_id_file").read()
+    token = open("my_token_file").read()
+except OSError:
+    print("Please authorise first using discovery.py")
+    exit()
 
+discover = RoonDiscovery(core_id)
+server = discover.first()
+discover.stop()
+roonapi = RoonApi(appinfo, token, server[0], server[1], True)
 
-# Take a look at examples/discovery if you want to use discovery.
-host = "192.168.3.61"
-port = 9330
-
-roonapi = RoonApi(appinfo, token, host, port)
 
 # get all zones (as dict)
 zones = roonapi.zones
@@ -39,7 +41,3 @@ for (k, v) in outputs.items():
         "grouped_zone_names:",
         grouped_zone_names,
     )
-
-# save the token for next time
-with open("mytokenfile", "w") as f:
-    f.write(roonapi.token)

--- a/examples/groups.py
+++ b/examples/groups.py
@@ -14,9 +14,10 @@ token = open("mytokenfile").read()
 
 
 # Take a look at examples/discovery if you want to use discovery.
-server = "192.168.3.60"
+host = "192.168.3.61"
+port = 9330
 
-roonapi = RoonApi(appinfo, token, server)
+roonapi = RoonApi(appinfo, token, host, port)
 
 # get all zones (as dict)
 zones = roonapi.zones

--- a/examples/play.py
+++ b/examples/play.py
@@ -1,4 +1,4 @@
-from roonapi import RoonApi
+from roonapi import RoonApi, RoonDiscovery
 
 appinfo = {
     "extension_id": "python_roon_test",
@@ -8,13 +8,20 @@ appinfo = {
     "email": "mygreat@emailaddress.com",
 }
 
-server = "192.168.3.61"
 target_zone = "Mixing Speakers"
-# Can be None if you don't yet have a token
-token = open("mytokenfile").read()
-port = 9330
 
-roonapi = RoonApi(appinfo, token, server, port)
+try:
+    core_id = open("my_core_id_file").read()
+    token = open("my_token_file").read()
+except OSError:
+    print("Please authorise first using discovery.py")
+    exit()
+
+discover = RoonDiscovery(core_id)
+server = discover.first()
+discover.stop()
+
+roonapi = RoonApi(appinfo, token, server[0], server[1], True)
 
 # get target zone output_id
 zones = roonapi.zones
@@ -44,7 +51,3 @@ items = roonapi.play_media(
 
 print("PLAY SUB GENRE")
 items = roonapi.play_media(output_id, ["Genres", "Jazz", "Cool"])
-
-# save the token for next time
-with open("mytokenfile", "w") as f:
-    f.write(roonapi.token)

--- a/examples/play.py
+++ b/examples/play.py
@@ -8,12 +8,13 @@ appinfo = {
     "email": "mygreat@emailaddress.com",
 }
 
-server = "192.168.3.60"
+server = "192.168.3.61"
 target_zone = "Mixing Speakers"
 # Can be None if you don't yet have a token
 token = open("mytokenfile").read()
+port = 9330
 
-roonapi = RoonApi(appinfo, token, server)
+roonapi = RoonApi(appinfo, token, server, port)
 
 # get target zone output_id
 zones = roonapi.zones

--- a/examples/play_error.py
+++ b/examples/play_error.py
@@ -8,12 +8,13 @@ appinfo = {
     "email": "mygreat@emailaddress.com",
 }
 
-server = "192.168.3.60"
+host = "192.168.3.61"
+port = 9330
 target_zone = "Mixing Speakers"
 # Can be None if you don't yet have a token
 token = open("mytokenfile").read()
 
-roonapi = RoonApi(appinfo, token, server)
+roonapi = RoonApi(appinfo, token, host, port)
 
 # get target zone output_id
 zones = roonapi.zones

--- a/examples/play_error.py
+++ b/examples/play_error.py
@@ -1,4 +1,4 @@
-from roonapi import RoonApi
+from roonapi import RoonApi, RoonDiscovery
 
 appinfo = {
     "extension_id": "python_roon_test",
@@ -8,13 +8,20 @@ appinfo = {
     "email": "mygreat@emailaddress.com",
 }
 
-host = "192.168.3.61"
-port = 9330
 target_zone = "Mixing Speakers"
-# Can be None if you don't yet have a token
-token = open("mytokenfile").read()
 
-roonapi = RoonApi(appinfo, token, host, port)
+try:
+    core_id = open("my_core_id_file").read()
+    token = open("my_token_file").read()
+except OSError:
+    print("Please authorise first using discovery.py")
+    exit()
+
+discover = RoonDiscovery(core_id)
+server = discover.first()
+discover.stop()
+
+roonapi = RoonApi(appinfo, token, server[0], server[1], True)
 
 # get target zone output_id
 zones = roonapi.zones
@@ -34,7 +41,3 @@ print("PLAY Something playable - this should work")
 items = roonapi.play_media(
     output_id, ["Qobuz", "My Qobuz", "Favorite Albums", "Grover Live"]
 )
-
-# save the token for next time
-with open("mytokenfile", "w") as f:
-    f.write(roonapi.token)

--- a/examples/subscription.py
+++ b/examples/subscription.py
@@ -1,6 +1,6 @@
 import time
 
-from roonapi import RoonApi
+from roonapi import RoonApi, RoonDiscovery
 
 appinfo = {
     "extension_id": "python_roon_test",
@@ -10,14 +10,18 @@ appinfo = {
     "email": "mygreat@emailaddress.com",
 }
 
-# Can be None if you don't yet have a token
-token = open("mytokenfile").read()
+try:
+    core_id = open("my_core_id_file").read()
+    token = open("my_token_file").read()
+except OSError:
+    print("Please authorise first using discovery.py")
+    exit()
 
-# Take a look at examples/discovery if you want to use discovery.
-host = "192.168.3.61"
-port = 9330
+discover = RoonDiscovery(core_id)
+server = discover.first()
+discover.stop()
 
-roonapi = RoonApi(appinfo, token, host, port)
+roonapi = RoonApi(appinfo, token, server[0], server[1], True)
 
 
 def my_state_callback(event, changed_ids):
@@ -32,7 +36,3 @@ def my_state_callback(event, changed_ids):
 roonapi.register_state_callback(my_state_callback)
 
 time.sleep(10)
-
-# save the token for next time
-with open("mytokenfile", "w") as f:
-    f.write(roonapi.token)

--- a/examples/subscription.py
+++ b/examples/subscription.py
@@ -14,9 +14,10 @@ appinfo = {
 token = open("mytokenfile").read()
 
 # Take a look at examples/discovery if you want to use discovery.
-server = "192.168.3.60"
+host = "192.168.3.61"
+port = 9330
 
-roonapi = RoonApi(appinfo, token, server)
+roonapi = RoonApi(appinfo, token, host, port)
 
 
 def my_state_callback(event, changed_ids):
@@ -30,7 +31,7 @@ def my_state_callback(event, changed_ids):
 # receive state updates in your callback
 roonapi.register_state_callback(my_state_callback)
 
-time.sleep(60)
+time.sleep(10)
 
 # save the token for next time
 with open("mytokenfile", "w") as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "roonapi"
-version = "0.0.39"
+version = "0.1.0"
 description = "Provides a python interface to interact with Roon"
 authors = [
     "Marcel van der Veldt",

--- a/roonapi/discovery.py
+++ b/roonapi/discovery.py
@@ -16,23 +16,18 @@ from .constants import SOOD_PORT, SOOD_MULTICAST_IP, LOGGER
 class RoonDiscovery(threading.Thread):
     """Class to discover Roon Servers connected in the network."""
 
-    def __init__(self, callback, core_id=None):
+    def __init__(self, core_id=None):
         """Discover Roon Servers connected in the network."""
         self._exit = threading.Event()
         self._core_id = core_id
-        if callback is None:
-            self._discovered_callback = lambda _a, _b: None
-        else:
-            self._discovered_callback = callback
         threading.Thread.__init__(self)
         self.daemon = True
 
     def run(self):
         """Run discovery until server found."""
         while not self._exit.isSet():
-            host, port = self.first()
+            host, _ = self.first()
             if host:
-                self._discovered_callback(host, port)
                 self.stop()
 
     def stop(self):


### PR DESCRIPTION
This PR will be a major version change, because clients will need to be slightly modified.

Firstly it removes the default discovery from inside the roon API - which didn't work in a number of circumstances.

It also removes the default port number - which was always unwise since roon ceate these on the fly - but was always wrong after roon changed their code.

The discovery example in the examples directory shows how to do find a roon core reliably. This is both the initial discovery needed to get authorisation, but also shows how to connect to a roon core with a known token and core_id - without needing to store the port or host. This is recommended since the host and especially the port can change.

Lastly this revises some of the startup logic which had a bug that would timeout fetching data when starting the API - which could take 6s.

