### PR TITLE
Reduce sleep at startup.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "roonapi"
-version = "0.1.0"
+version = "0.1.1"
 description = "Provides a python interface to interact with Roon"
 authors = [
     "Marcel van der Veldt",

--- a/roonapi/roonapi.py
+++ b/roonapi/roonapi.py
@@ -696,7 +696,7 @@ class RoonApi:  # pylint: disable=too-many-instance-attributes
         # block untill we're ready
         if blocking_init:
             while not self.ready and not self._exit:
-                time.sleep(1)
+                time.sleep(0.05)
 
         # fill zones and outputs dicts one time so the data is available right away
         # This might not be needed as the on change callback may have already done this


### PR DESCRIPTION
As suggested by @doctorfree this was much longer than it seems was needed.

I tried this on both a local Roon core - and a remote one - and in both cases the code only looped and waited once, so I don't expect it's going to use any more cpu.