### PR TITLE
Fix crash when attempting to play a tag

### DIFF
--- a/roonapi/roonapi.py
+++ b/roonapi/roonapi.py
@@ -576,11 +576,11 @@ class RoonApi:  # pylint: disable=too-many-instance-attributes
                 return False
             take_action = found_actions[0]
 
-        if take_action["hint"] != "action":
+        if take_action.get("hint") != "action":
             LOGGER.error(
                 "Found media does not have playable action %s - %s",
                 take_action["title"],
-                take_action["hint"],
+                take_action.get("hint"),
             )
             return False
 


### PR DESCRIPTION
This commit fixes a crash when playing a tag like this:

    roon.play_media(zone_id, ["Library", "Tags", "mytag"])

This does not fix the playing of the tag (that still doesn't work), but it prevents a KeyError exception from being thrown because the "hint" field doesn't exist.

Related to #59 