### PR TITLE
Improve path parsing in split_media_path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,13 @@
 __pycache__
 .DS_Store
 build/
-roon_test_token.txt
+test_token_file
+test_core_server_file
+test_core_port_file
 dist/
 roonapi.egg-info/
 .venv
 venv
 my_token_file
 my_core_id_file
+.python-version

--- a/roonapi/roonapi.py
+++ b/roonapi/roonapi.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
-import os
 import threading
 import time
+import csv
 
 from .constants import (
     LOGGER,
@@ -17,20 +17,7 @@ from .roonapisocket import RoonApiWebSocket
 def split_media_path(path):
     """Split a path (eg path/to/media) into a list for use by play_media."""
 
-    allparts = []
-    while 1:
-        parts = os.path.split(path)
-        if parts[0] == path:  # sentinel for absolute paths
-            allparts.insert(0, parts[0])
-            break
-
-        if parts[1] == path:  # sentinel for relative paths
-            allparts.insert(0, parts[1])
-            break
-
-        path = parts[0]
-        allparts.insert(0, parts[1])
-    return allparts
+    return [*csv.reader([path], delimiter="/")][0]
 
 
 class RoonApi:  # pylint: disable=too-many-instance-attributes

--- a/tests/test__discovery.py
+++ b/tests/test__discovery.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Init and test discovery to test the roon api."""
+
+import os.path
+
+from roonapi import RoonApi, RoonDiscovery
+
+
+appinfo = {
+    "extension_id": "python_roon_test",
+    "display_name": "Python library for Roon",
+    "display_version": "1.0.0",
+    "publisher": "pavoni",
+    "email": "my@email.com",
+}
+
+
+def test_discovery():
+    try:
+        core_id = open("my_core_id_file").read()
+        token = open("my_token_file").read()
+    except OSError:
+        print("Please authorise first using discovery.py")
+        exit()
+
+    discover = RoonDiscovery(core_id)
+    server = discover.first()
+    discover.stop()
+
+    assert server[0] != None
+    assert server[1] != None
+
+    with RoonApi(appinfo, token, server[0], server[1], True) as roonapi:
+        token = roonapi.token
+        roonapi.stop()
+
+    with open("test_core_server_file", "w") as f:
+        f.write(server[0])
+    with open("test_core_port_file", "w") as f:
+        f.write(server[1])
+    with open("test_token_file", "w") as f:
+        f.write(roonapi.token)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -7,110 +7,44 @@ import os.path
 
 from roonapi import RoonApi
 
-token = None
-if os.path.isfile("roon_test_token.txt"):
-    with open("roon_test_token.txt") as f:
-        token = f.read()
 
-appinfo = {
-    "extension_id": "python_roon_test",
-    "display_name": "Python library for Roon",
-    "display_version": "1.0.0",
-    "publisher": "pavoni",
-    "email": "my@email.com",
-}
+def test_basic():
 
-# with RoonApi(appinfo, token, host, blocking_init=True) as roonapi:
-with RoonApi(appinfo, token, None, blocking_init=True) as roonapi:
+    try:
+        host = open("test_core_server_file").read()
+        port = open("test_core_port_file").read()
+        token = open("my_token_file").read()
+    except OSError:
+        print("Please authorise first using discovery.py")
+        exit()
 
-    # Test basic zone fetching
-    zones = [zone["display_name"] for zone in roonapi.zones.values()]
-    zones.sort()
-    assert len(zones) == 6
-    assert zones == [
-        "Bedroom",
-        "Hi Fi",
-        "Kitchen",
-        "Mixing Speakers",
-        "Shower",
-        "Study",
-    ]
+    appinfo = {
+        "extension_id": "python_roon_test",
+        "display_name": "Python library for Roon",
+        "display_version": "1.0.0",
+        "publisher": "pavoni",
+        "email": "my@email.com",
+    }
 
-    # Test basic output fetching
-    output_count = len(roonapi.outputs)
-    assert output_count == 6
+    with RoonApi(appinfo, token, host, port, True) as roonapi:
 
-    # Test basic browsing
-    result = roonapi.browse_by_path([])
-    assert list(result) == ["items", "offset", "list"]
+        # Test basic zone fetching
+        zones = [zone["display_name"] for zone in roonapi.zones.values()]
+        zones.sort()
+        assert len(zones) == 7
+        assert zones == [
+            "95 Office",
+            "Bedroom",
+            "Hi Fi",
+            "Kitchen",
+            "Shower",
+            "Study",
+            "Tuner",
+        ]
 
-    headers = [item["title"] for item in result["items"]]
+        # Test basic output fetching
+        output_count = len(roonapi.outputs)
+        assert output_count == 8
 
-    assert "Library" in headers
-    assert "Playlists" in headers
-    assert "Internet Radio" in headers
-    assert "Genres" in headers
-    assert "Settings" in headers
-
-    # print(" ###### main menu browse ######")
-    # # items at first level (mainmenu items)
-    # result = roonapi.browse_by_path([])
-    # print([item["title"] for item in result["items"]])
-
-    # print(" ###### search artist ######")
-    # result = roonapi.browse_by_path(["Library", "Search", "Artists"], search_input="ABBA")
-    # print([item["title"] for item in result["items"]])
-
-    # print(" ###### genres ######")
-    # result = roonapi.genres()
-    # print([item["title"] for item in result["items"]])
-
-    # print(" ###### subgenres ######")
-    # result = roonapi.genres("Pop/Rock")
-    # print([item["title"] for item in result["items"]])
-
-    # print(" ###### zones ######")
-    # for zone in roonapi.zones.values():
-    #     print(zone["display_name"])
-
-    # print(" ###### playlists ######")
-    # items = roonapi.playlists()
-    # print("number of playlists: %s" % items["list"]["count"])
-
-    # print(" ###### artists ######")
-    # items = roonapi.artists()
-    # print("number of artists: %s" % items["list"]["count"])
-
-    # print(" ###### albums ######")
-    # items = roonapi.albums()
-    # print("number of albums: %s" % items["list"]["count"])
-
-    # print(" ###### tracks ######")
-    # items = roonapi.tracks(offset=200)
-    # print("number of tracks: %s" % items["list"]["count"])
-
-    # # play playlist by name
-    # zone_id = roonapi.zone_by_output_name("milo")["zone_id"]
-    # output_id = roonapi.output_by_name("milo")["output_id"]
-    # roonapi.play_playlist(zone_id, "Kids")
-
-    # # some playback controls
-    # time.sleep(5)
-    # roonapi.playback_control(zone_id, "pause")
-    # time.sleep(2)
-    # roonapi.playback_control(zone_id, "play")
-    # time.sleep(2)
-    # roonapi.change_volume(output_id, 60)
-    # time.sleep(2)
-    # roonapi.change_volume(output_id, 40)
-
-    # # play genre
-    # roonapi.play_genre(zone_id, "Pop/Rock")
-
-    # save token
-    token = roonapi.token
-    roonapi.stop()
-
-print("Saving token: %s" % token)
-with open("roon_test_token.txt", "w") as f:
-    f.write(token)
+        token = roonapi.token
+        roonapi.stop()

--- a/tests/test_path_parser.py
+++ b/tests/test_path_parser.py
@@ -42,7 +42,6 @@ def test_simple_paths():
 def test_edge_cases():
 
     assert split_media_path("") == [
-        "",
     ]
 
     assert split_media_path("Library") == [
@@ -50,7 +49,8 @@ def test_edge_cases():
     ]
 
     assert split_media_path("/") == [
-        "/",
+    "",
+    ""
     ]
 
 
@@ -67,13 +67,7 @@ def test_quoted_paths():
         "Rock/Pop",
     ]
 
-    assert split_media_path("'Library'/Artists/Neil Young") == [
-        "Library",
-        "Artists",
-        "Neil Young",
-    ]
-
-    assert split_media_path("Genres/'Rock/Pop'") == [
+    assert split_media_path("Genres/\"Rock/Pop\"") == [
         "Genres",
         "Rock/Pop",
     ]

--- a/tests/test_path_parser.py
+++ b/tests/test_path_parser.py
@@ -1,0 +1,79 @@
+# !/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from roonapi import split_media_path
+
+"""Some tests of the path parser"""
+
+
+def test_simple_paths():
+
+    assert split_media_path("Library/Artists/Neil Young") == [
+        "Library",
+        "Artists",
+        "Neil Young",
+    ]
+
+    assert split_media_path("Library/Artists/Neil Young/Harvest") == [
+        "Library",
+        "Artists",
+        "Neil Young",
+        "Harvest",
+    ]
+
+    assert split_media_path("My Live Radio/BBC Radio 4") == [
+        "My Live Radio",
+        "BBC Radio 4",
+    ]
+
+    assert split_media_path("Genres/Jazz/Cool") == [
+        "Genres",
+        "Jazz",
+        "Cool",
+    ]
+
+    assert split_media_path("Genres/Rock/Pop") == [
+        "Genres",
+        "Rock",
+        "Pop",
+    ]
+
+
+def test_edge_cases():
+
+    assert split_media_path("") == [
+        "",
+    ]
+
+    assert split_media_path("Library") == [
+        "Library",
+    ]
+
+    assert split_media_path("/") == [
+        "/",
+    ]
+
+
+def test_quoted_paths():
+
+    assert split_media_path('"Library"/Artists/Neil Young') == [
+        "Library",
+        "Artists",
+        "Neil Young",
+    ]
+
+    assert split_media_path('Genres/"Rock/Pop"') == [
+        "Genres",
+        "Rock/Pop",
+    ]
+
+    assert split_media_path("'Library'/Artists/Neil Young") == [
+        "Library",
+        "Artists",
+        "Neil Young",
+    ]
+
+    assert split_media_path("Genres/'Rock/Pop'") == [
+        "Genres",
+        "Rock/Pop",
+    ]

--- a/tests/test_path_parser.py
+++ b/tests/test_path_parser.py
@@ -41,17 +41,13 @@ def test_simple_paths():
 
 def test_edge_cases():
 
-    assert split_media_path("") == [
-    ]
+    assert split_media_path("") == []
 
     assert split_media_path("Library") == [
         "Library",
     ]
 
-    assert split_media_path("/") == [
-    "",
-    ""
-    ]
+    assert split_media_path("/") == ["", ""]
 
 
 def test_quoted_paths():
@@ -67,7 +63,7 @@ def test_quoted_paths():
         "Rock/Pop",
     ]
 
-    assert split_media_path("Genres/\"Rock/Pop\"") == [
+    assert split_media_path('Genres/"Rock/Pop"') == [
         "Genres",
         "Rock/Pop",
     ]

--- a/tests/test_with_callbacks.py
+++ b/tests/test_with_callbacks.py
@@ -7,62 +7,62 @@ import os.path
 
 from roonapi import RoonApi, LOGGER
 
-token = None
-if os.path.isfile("roon_test_token.txt"):
-    with open("roon_test_token.txt") as f:
-        token = f.read()
 
-appinfo = {
-    "extension_id": "python_roon_test",
-    "display_name": "Python library for Roon",
-    "display_version": "1.0.0",
-    "publisher": "pavoni",
-    "email": "my@email.com",
-}
+def test_callbacks():
+    callback_count = 0
+    events = []
 
-callback_count = 0
-events = []
+    try:
+        host = open("test_core_server_file").read()
+        port = open("test_core_port_file").read()
+        token = open("my_token_file").read()
+    except OSError:
+        print("Please authorise first using discovery.py")
+        exit()
 
+    appinfo = {
+        "extension_id": "python_roon_test",
+        "display_name": "Python library for Roon",
+        "display_version": "1.0.0",
+        "publisher": "pavoni",
+        "email": "my@email.com",
+    }
 
-def state_callback(event, changed_items):
-    """Update details when the roon state changes."""
-    global callback_count, events
-    callback_count += 1
-    events.append(event)
-    LOGGER.info("%s: %s", event, changed_items)
+    # initialize Roon api and register the callback for state changes
+    with RoonApi(appinfo, token, host, port, True) as roonapi:
 
+        def state_callback(event, changed_items):
+            """Update details when the roon state changes."""
+            nonlocal callback_count, events
+            callback_count += 1
+            events.append(event)
+            LOGGER.info("%s: %s", event, changed_items)
 
-# initialize Roon api and register the callback for state changes
-host = "192.168.1.160"
-roonapi = RoonApi(appinfo, token, host)
+        roonapi.register_state_callback(state_callback)
 
-roonapi.register_state_callback(state_callback)
+        zones = [
+            zone
+            for zone in roonapi.zones.values()
+            if zone["display_name"] == "95 Office"
+        ]
 
-zones = [
-    zone for zone in roonapi.zones.values() if zone["display_name"] == "Mixing Speakers"
-]
+        assert len(zones) == 1
 
-assert len(zones) == 1
+        test_zone = zones[0]
+        test_output_id = test_zone["outputs"][0]["output_id"]
 
-test_zone = zones[0]
-test_output_id = test_zone["outputs"][0]["output_id"]
+        assert callback_count == 0
+        assert events == []
 
-assert callback_count == 0
-assert events == []
+        roonapi.change_volume(test_output_id, 1, method="relative")
+        assert callback_count == 2
+        assert events == ["zones_changed", "outputs_changed"]
 
-roonapi.change_volume(test_output_id, 1, method="relative")
-assert callback_count == 2
-assert events == ["zones_changed", "outputs_changed"]
+        events = []
 
-events = []
+        roonapi.change_volume(test_output_id, -1, method="relative")
+        assert callback_count == 4
+        assert events == ["zones_changed", "outputs_changed"]
 
-roonapi.change_volume(test_output_id, -1, method="relative")
-assert callback_count == 4
-assert events == ["zones_changed", "outputs_changed"]
-
-roonapi.stop()
-token = roonapi.token
-print("Saving token: %s" % token)
-if token:
-    with open("roon_test_token.txt", "w") as f:
-        f.write(token)
+        roonapi.stop()
+        token = roonapi.token


### PR DESCRIPTION
This PR improves the path parsing to understand simple quoting in `split_media_path`.

This will allow HA users (who are the main users of this utility function) to play albums and genres that contain the `/` character.

So it will now be possible to play `Library/Genres/\"Rock\Pop\"`.

To do this I also updated the local tests which were out of date - they continue to require a local roon core - and so can't run on github. But I also added some path relates tests so I could check I wasn't breaking anything serious!

At some point we could split the tests - and run theones that don't require a roon core on github.

Closes https://github.com/pavoni/pyroon/issues/56
