### PR TITLE
Revise volume logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "roonapi"
-version = "0.1.2"
+version = "0.1.3"
 description = "Provides a python interface to interact with Roon"
 authors = [
     "Marcel van der Veldt",

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -28,17 +28,17 @@ def roon_api(request):
 
     def teardown():
         roonapi.stop()
+
     request.addfinalizer(teardown)
 
     # initialize Roon api and register the callback for state changes
     roonapi = RoonApi(appinfo, token, host, port, True)
     return roonapi
 
+
 def test_get_volume_db(roon_api):
     db_zone = [
-        zone
-        for zone in roon_api.zones.values()
-        if zone["display_name"] == "95 Office"
+        zone for zone in roon_api.zones.values() if zone["display_name"] == "95 Office"
     ][0]
 
     db_zone_volume_info = db_zone["outputs"][0]["volume"]
@@ -51,6 +51,7 @@ def test_get_volume_db(roon_api):
 
     roon_api.change_volume_raw(db_zone_output_id, -40)
     assert roon_api.get_volume_percent(db_zone_output_id) == 50
+
 
 def test_get_volume_perent(roon_api):
     percent_zone = [
@@ -70,11 +71,10 @@ def test_get_volume_perent(roon_api):
     roon_api.change_volume_raw(percent_zone_output_id, 50)
     assert roon_api.get_volume_percent(percent_zone_output_id) == 50
 
+
 def test_set_volume_db(roon_api):
     db_zone = [
-        zone
-        for zone in roon_api.zones.values()
-        if zone["display_name"] == "95 Office"
+        zone for zone in roon_api.zones.values() if zone["display_name"] == "95 Office"
     ][0]
 
     db_zone_volume_info = db_zone["outputs"][0]["volume"]
@@ -88,6 +88,7 @@ def test_set_volume_db(roon_api):
 
     roon_api.set_volume_percent(db_zone_output_id, 50)
     assert roon_api.get_volume_percent(db_zone_output_id) == 50
+
 
 def test_set_volume_percent(roon_api):
     percent_zone = [
@@ -108,11 +109,10 @@ def test_set_volume_percent(roon_api):
     roon_api.set_volume_percent(percent_zone_output_id, 50)
     assert roon_api.get_volume_percent(percent_zone_output_id) == 50
 
+
 def test_change_volume_db(roon_api):
     db_zone = [
-        zone
-        for zone in roon_api.zones.values()
-        if zone["display_name"] == "95 Office"
+        zone for zone in roon_api.zones.values() if zone["display_name"] == "95 Office"
     ][0]
 
     db_zone_volume_info = db_zone["outputs"][0]["volume"]
@@ -126,6 +126,7 @@ def test_change_volume_db(roon_api):
 
     roon_api.change_volume_percent(db_zone_output_id, -2)
     assert roon_api.get_volume_percent(db_zone_output_id) == 39
+
 
 def test_change_volume_percent(roon_api):
     percent_zone = [

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -43,13 +43,31 @@ def test_get_volume_db(roon_api):
 
     db_zone_volume_info = db_zone["outputs"][0]["volume"]
     db_zone_output_id = db_zone["outputs"][0]["output_id"]
+
     roon_api.change_volume_raw(db_zone_output_id, -80)
+
+    vol = [
+        zone for zone in roon_api.zones.values() if zone["display_name"] == "95 Office"
+    ][0]["outputs"][0]["volume"]["value"]
+    assert vol == -80
+
     assert roon_api.get_volume_percent(db_zone_output_id) == 0
 
     roon_api.change_volume_raw(db_zone_output_id, 0)
+
+    vol = [
+        zone for zone in roon_api.zones.values() if zone["display_name"] == "95 Office"
+    ][0]["outputs"][0]["volume"]["value"]
+    assert vol == 0
+
     assert roon_api.get_volume_percent(db_zone_output_id) == 100
 
     roon_api.change_volume_raw(db_zone_output_id, -40)
+    vol = [
+        zone for zone in roon_api.zones.values() if zone["display_name"] == "95 Office"
+    ][0]["outputs"][0]["volume"]["value"]
+    assert vol == -40
+
     assert roon_api.get_volume_percent(db_zone_output_id) == 50
 
 
@@ -62,13 +80,37 @@ def test_get_volume_perent(roon_api):
 
     percent_zone_volume_info = percent_zone["outputs"][0]["volume"]
     percent_zone_output_id = percent_zone["outputs"][0]["output_id"]
+
     roon_api.change_volume_raw(percent_zone_output_id, 0)
+
+    vol = [
+        zone
+        for zone in roon_api.zones.values()
+        if zone["display_name"] == "Gregs Mac System"
+    ][0]["outputs"][0]["volume"]["value"]
+    assert vol == 0
+
     assert roon_api.get_volume_percent(percent_zone_output_id) == 0
 
     roon_api.change_volume_raw(percent_zone_output_id, 100)
+    vol = [
+        zone
+        for zone in roon_api.zones.values()
+        if zone["display_name"] == "Gregs Mac System"
+    ][0]["outputs"][0]["volume"]["value"]
+    assert vol == 100
+
     assert roon_api.get_volume_percent(percent_zone_output_id) == 100
 
     roon_api.change_volume_raw(percent_zone_output_id, 50)
+
+    vol = [
+        zone
+        for zone in roon_api.zones.values()
+        if zone["display_name"] == "Gregs Mac System"
+    ][0]["outputs"][0]["volume"]["value"]
+    assert vol == 50
+
     assert roon_api.get_volume_percent(percent_zone_output_id) == 50
 
 

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Some simple tests for callback on the roon api."""
+
+import os.path, pytest
+
+from roonapi import RoonApi, LOGGER
+
+
+@pytest.fixture()
+def roon_api(request):
+    try:
+        host = open("test_core_server_file").read()
+        port = open("test_core_port_file").read()
+        token = open("my_token_file").read()
+    except OSError:
+        print("Please authorise first using discovery.py")
+        exit()
+
+    appinfo = {
+        "extension_id": "python_roon_test",
+        "display_name": "Python library for Roon",
+        "display_version": "1.0.0",
+        "publisher": "pavoni",
+        "email": "my@email.com",
+    }
+
+    def teardown():
+        roonapi.stop()
+    request.addfinalizer(teardown)
+
+    # initialize Roon api and register the callback for state changes
+    roonapi = RoonApi(appinfo, token, host, port, True)
+    return roonapi
+
+def test_get_volume_db(roon_api):
+    db_zone = [
+        zone
+        for zone in roon_api.zones.values()
+        if zone["display_name"] == "95 Office"
+    ][0]
+
+    db_zone_volume_info = db_zone["outputs"][0]["volume"]
+    db_zone_output_id = db_zone["outputs"][0]["output_id"]
+    roon_api.change_volume_raw(db_zone_output_id, -80)
+    assert roon_api.get_volume_percent(db_zone_output_id) == 0
+
+    roon_api.change_volume_raw(db_zone_output_id, 0)
+    assert roon_api.get_volume_percent(db_zone_output_id) == 100
+
+    roon_api.change_volume_raw(db_zone_output_id, -40)
+    assert roon_api.get_volume_percent(db_zone_output_id) == 50
+
+def test_get_volume_perent(roon_api):
+    percent_zone = [
+        zone
+        for zone in roon_api.zones.values()
+        if zone["display_name"] == "Gregs Mac System"
+    ][0]
+
+    percent_zone_volume_info = percent_zone["outputs"][0]["volume"]
+    percent_zone_output_id = percent_zone["outputs"][0]["output_id"]
+    roon_api.change_volume_raw(percent_zone_output_id, 0)
+    assert roon_api.get_volume_percent(percent_zone_output_id) == 0
+
+    roon_api.change_volume_raw(percent_zone_output_id, 100)
+    assert roon_api.get_volume_percent(percent_zone_output_id) == 100
+
+    roon_api.change_volume_raw(percent_zone_output_id, 50)
+    assert roon_api.get_volume_percent(percent_zone_output_id) == 50
+
+def test_set_volume_db(roon_api):
+    db_zone = [
+        zone
+        for zone in roon_api.zones.values()
+        if zone["display_name"] == "95 Office"
+    ][0]
+
+    db_zone_volume_info = db_zone["outputs"][0]["volume"]
+    db_zone_output_id = db_zone["outputs"][0]["output_id"]
+
+    roon_api.set_volume_percent(db_zone_output_id, 0)
+    assert roon_api.get_volume_percent(db_zone_output_id) == 0
+
+    roon_api.set_volume_percent(db_zone_output_id, 100)
+    assert roon_api.get_volume_percent(db_zone_output_id) == 100
+
+    roon_api.set_volume_percent(db_zone_output_id, 50)
+    assert roon_api.get_volume_percent(db_zone_output_id) == 50
+
+def test_set_volume_percent(roon_api):
+    percent_zone = [
+        zone
+        for zone in roon_api.zones.values()
+        if zone["display_name"] == "Gregs Mac System"
+    ][0]
+
+    percent_zone_volume_info = percent_zone["outputs"][0]["volume"]
+    percent_zone_output_id = percent_zone["outputs"][0]["output_id"]
+
+    roon_api.set_volume_percent(percent_zone_output_id, 0)
+    assert roon_api.get_volume_percent(percent_zone_output_id) == 0
+
+    roon_api.set_volume_percent(percent_zone_output_id, 100)
+    assert roon_api.get_volume_percent(percent_zone_output_id) == 100
+
+    roon_api.set_volume_percent(percent_zone_output_id, 50)
+    assert roon_api.get_volume_percent(percent_zone_output_id) == 50
+
+def test_change_volume_db(roon_api):
+    db_zone = [
+        zone
+        for zone in roon_api.zones.values()
+        if zone["display_name"] == "95 Office"
+    ][0]
+
+    db_zone_volume_info = db_zone["outputs"][0]["volume"]
+    db_zone_output_id = db_zone["outputs"][0]["output_id"]
+
+    roon_api.set_volume_percent(db_zone_output_id, 40)
+    assert roon_api.get_volume_percent(db_zone_output_id) == 40
+
+    roon_api.change_volume_percent(db_zone_output_id, 1)
+    assert roon_api.get_volume_percent(db_zone_output_id) == 41
+
+    roon_api.change_volume_percent(db_zone_output_id, -2)
+    assert roon_api.get_volume_percent(db_zone_output_id) == 39
+
+def test_change_volume_percent(roon_api):
+    percent_zone = [
+        zone
+        for zone in roon_api.zones.values()
+        if zone["display_name"] == "Gregs Mac System"
+    ][0]
+
+    percent_zone_volume_info = percent_zone["outputs"][0]["volume"]
+    percent_zone_output_id = percent_zone["outputs"][0]["output_id"]
+
+    roon_api.set_volume_percent(percent_zone_output_id, 40)
+    assert roon_api.get_volume_percent(percent_zone_output_id) == 40
+
+    roon_api.change_volume_percent(percent_zone_output_id, 1)
+    assert roon_api.get_volume_percent(percent_zone_output_id) == 41
+
+    roon_api.change_volume_percent(percent_zone_output_id, -2)
+    assert roon_api.get_volume_percent(percent_zone_output_id) == 39

--- a/tests/test_with_callbacks.py
+++ b/tests/test_with_callbacks.py
@@ -54,15 +54,14 @@ def test_callbacks():
         assert callback_count == 0
         assert events == []
 
-        roonapi.change_volume(test_output_id, 1, method="relative")
+        roonapi.change_volume_raw(test_output_id, 1, method="relative")
         assert callback_count == 2
         assert events == ["zones_changed", "outputs_changed"]
 
         events = []
 
-        roonapi.change_volume(test_output_id, -1, method="relative")
+        roonapi.change_volume_raw(test_output_id, -1, method="relative")
         assert callback_count == 4
         assert events == ["zones_changed", "outputs_changed"]
 
         roonapi.stop()
-        token = roonapi.token


### PR DESCRIPTION
This PR refactors the pyroon volume logic.

It removes a db to percentage conversation from the `change_volume` method - which made some assumptions about roon endpoints that weren't always correct. Because of that this is a breaking change - so I've renamed the method `change_volume_raw` to make it more obvious.

I've also added three new methods to get, set and increment/decrement the volume on a percentage basis - which use the additional data roon provides about endpoints. These methods are based on code from @juliusvaart (thanks).

@juliusvaart also found that the 'type: db' parameter isn't always set for endpoints that are scaled in db - so this new logic avoids depending on this!

I've also added some simple tests - but they require a roon core (and are dependant on my setup) - so can't be run on github.

@juliusvaart could you take a look?

@doctorfree when released this may require some (small) changes to your code.

Closes https://github.com/pavoni/pyroon/issues/55