### PR TITLE
Fix play media exceptions

### DIFF
--- a/examples/play.py
+++ b/examples/play.py
@@ -51,3 +51,6 @@ items = roonapi.play_media(
 
 print("PLAY SUB GENRE")
 items = roonapi.play_media(output_id, ["Genres", "Jazz", "Cool"])
+
+print("TAG")
+items = roonapi.play_media(output_id, ["Library", "Tags", "Mix"])

--- a/examples/play_error.py
+++ b/examples/play_error.py
@@ -39,5 +39,5 @@ items = roonapi.play_media(output_id, ["Qobuz", "My Qobuz", "Favorite Albums"])
 
 print("PLAY Something playable - this should work")
 items = roonapi.play_media(
-    output_id, ["Qobuz", "My Qobuz", "Favorite Albums", "Grover Live"]
+    output_id, ["Qobuz", "My Qobuz", "Favorite Albums", "Umiera Piekno"]
 )

--- a/roonapi/roonapi.py
+++ b/roonapi/roonapi.py
@@ -541,7 +541,7 @@ class RoonApi:  # pylint: disable=too-many-instance-attributes
         return matched
 
     def play_media(self, zone_or_output_id, path, action=None, report_error=True):
-        # pylint: disable=too-many-locals,too-many-branches,too-many-return-statements
+        # pylint: disable=too-many-locals,too-many-branches,too-many-return-statements,too-many-statements
         """
         Play the media specified.
 
@@ -642,13 +642,19 @@ class RoonApi:  # pylint: disable=too-many-instance-attributes
                 return False
             take_action = found_actions[0]
 
-        if take_action["hint"] != "action":
-            LOGGER.error(
-                "Found media does not have playable action %s - %s",
-                take_action["title"],
-                take_action["hint"],
-            )
-            return False
+            try:
+                if take_action["hint"] != "action":
+                    LOGGER.error(
+                        "Found media does not have playable action %s - %s",
+                        take_action["title"],
+                        take_action["hint"],
+                    )
+                    return False
+            except KeyError:
+                # I think this is a roon API error -
+                # when playing a tag - there should be a hint here!
+                # so for now just ignore - and hope it's OK
+                pass
 
         opts["item_key"] = take_action["item_key"]
         load_opts["item_key"] = take_action["item_key"]

--- a/roonapi/roonapi.py
+++ b/roonapi/roonapi.py
@@ -541,7 +541,7 @@ class RoonApi:  # pylint: disable=too-many-instance-attributes
         return matched
 
     def play_media(self, zone_or_output_id, path, action=None, report_error=True):
-        # pylint: disable=too-many-locals,too-many-branches
+        # pylint: disable=too-many-locals,too-many-branches,too-many-return-statements
         """
         Play the media specified.
 
@@ -598,7 +598,11 @@ class RoonApi:  # pylint: disable=too-many-instance-attributes
             opts["item_key"] = found["item_key"]
             load_opts["item_key"] = found["item_key"]
 
-            total_count = self.browse_browse(opts)["list"]["count"]
+            try:
+                total_count = self.browse_browse(opts)["list"]["count"]
+            except TypeError:
+                LOGGER.error("Exception trying to play media")
+                return None
 
             load_opts["offset"] = 0
             items = self.browse_load(load_opts)["items"]


### PR DESCRIPTION
Fix two exceptions when trying to `play_media`

One is when trying to play on a non live player.

Fixes https://github.com/pavoni/pyroon/issues/66

The other is likely a bug in the roon api when trying to play tags.

Fixes https://github.com/pavoni/pyroon/issues/59
