### PR TITLE
Add extra loop option

### DIFF
--- a/roonapi/roonapi.py
+++ b/roonapi/roonapi.py
@@ -365,15 +365,21 @@ class RoonApi:  # pylint: disable=too-many-instance-attributes, too-many-lines
         data = {"zone_or_output_id": zone_or_output_id, "shuffle": shuffle}
         return self._request(SERVICE_TRANSPORT + "/change_settings", data)
 
-    def repeat(self, zone_or_output_id, repeat=True):
+    def repeat(self, zone_or_output_id, repeat="loop"):
         """
         Enable/disable playing in a loop.
 
         params:
             zone_or_output_id: the id of the output or zone
-            repeat: bool if repeat should be enabled. False will disable shuffle
+            repeat: "loop", "loop_one", "disabled"
+
+        For backward compatability repeat can also be boolean with true meaning "loop" and false "disabled"
         """
-        loop = "loop" if repeat else "disabled"
+        if repeat in ("loop", "loop_one", "disabled"):
+            loop = repeat
+        else:
+            loop = "loop" if repeat else "disabled"
+
         data = {"zone_or_output_id": zone_or_output_id, "loop": loop}
         return self._request(SERVICE_TRANSPORT + "/change_settings", data)
 

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Some simple tests for callback on the roon api."""
+
+import os.path, pytest
+
+from roonapi import RoonApi, LOGGER
+
+
+@pytest.fixture()
+def roon_api(request):
+    try:
+        host = open("test_core_server_file").read()
+        port = open("test_core_port_file").read()
+        token = open("my_token_file").read()
+    except OSError:
+        print("Please authorise first using discovery.py")
+        exit()
+
+    appinfo = {
+        "extension_id": "python_roon_test",
+        "display_name": "Python library for Roon",
+        "display_version": "1.0.0",
+        "publisher": "pavoni",
+        "email": "my@email.com",
+    }
+
+    def teardown():
+        roonapi.stop()
+
+    request.addfinalizer(teardown)
+
+    # initialize Roon api and register the callback for state changes
+    roonapi = RoonApi(appinfo, token, host, port, True)
+    return roonapi
+
+
+def test_loop_settings(roon_api):
+    db_zone = [
+        zone for zone in roon_api.zones.values() if zone["display_name"] == "95 Office"
+    ][0]
+
+    db_zone_output_id = db_zone["outputs"][0]["output_id"]
+
+    loop = db_zone["settings"]["loop"]
+    assert loop == "disabled"
+
+    roon_api.repeat(db_zone_output_id, "loop_one")
+
+    db_zone = [
+        zone for zone in roon_api.zones.values() if zone["display_name"] == "95 Office"
+    ][0]
+
+    db_zone_output_id = db_zone["outputs"][0]["output_id"]
+
+    loop = db_zone["settings"]["loop"]
+    assert loop == "loop_one"
+
+    roon_api.repeat(db_zone_output_id, "loop")
+
+    db_zone = [
+        zone for zone in roon_api.zones.values() if zone["display_name"] == "95 Office"
+    ][0]
+
+    db_zone_output_id = db_zone["outputs"][0]["output_id"]
+
+    loop = db_zone["settings"]["loop"]
+    assert loop == "loop"
+
+    roon_api.repeat(db_zone_output_id, "disabled")
+
+    db_zone = [
+        zone for zone in roon_api.zones.values() if zone["display_name"] == "95 Office"
+    ][0]
+
+    db_zone_output_id = db_zone["outputs"][0]["output_id"]
+
+    loop = db_zone["settings"]["loop"]
+    assert loop == "disabled"
+
+
+def test_loop_old_style_settings(roon_api):
+    db_zone = [
+        zone for zone in roon_api.zones.values() if zone["display_name"] == "95 Office"
+    ][0]
+
+    db_zone_output_id = db_zone["outputs"][0]["output_id"]
+
+    loop = db_zone["settings"]["loop"]
+    assert loop == "disabled"
+
+    roon_api.repeat(db_zone_output_id, True)
+
+    db_zone = [
+        zone for zone in roon_api.zones.values() if zone["display_name"] == "95 Office"
+    ][0]
+
+    db_zone_output_id = db_zone["outputs"][0]["output_id"]
+
+    loop = db_zone["settings"]["loop"]
+    assert loop == "loop"
+
+    roon_api.repeat(db_zone_output_id, False)
+
+    db_zone = [
+        zone for zone in roon_api.zones.values() if zone["display_name"] == "95 Office"
+    ][0]
+
+    db_zone_output_id = db_zone["outputs"][0]["output_id"]
+
+    loop = db_zone["settings"]["loop"]
+    assert loop == "disabled"
+
+    roon_api.repeat(db_zone_output_id)
+
+    db_zone = [
+        zone for zone in roon_api.zones.values() if zone["display_name"] == "95 Office"
+    ][0]
+
+    db_zone_output_id = db_zone["outputs"][0]["output_id"]
+
+    loop = db_zone["settings"]["loop"]
+    assert loop == "loop"
+
+    roon_api.repeat(db_zone_output_id, False)


### PR DESCRIPTION
Adjust the `repeat` method to take string parameter, so it can support `loop_one` as well as `loop` and `disabled`.

It was straightforward  to still allow the previous boolean parameter - so I did this too.

Also added simple test (that will only run in my environment).

Closes https://github.com/pavoni/pyroon/issues/58